### PR TITLE
fix: resolve absence filter reset on month change

### DIFF
--- a/Aplikácia/ajax/overview_load.php
+++ b/Aplikácia/ajax/overview_load.php
@@ -32,5 +32,6 @@ $overview = new Overview($year, $month, $pid, $personal_id);
 
 // vykresli nahlad
 echo $overview->run( $title );
+echo '<script>filter_employees();</script>';
 
 ?>


### PR DESCRIPTION
Problem:
- Absences were loading without calling the filter method at the end when switching between months in the overview table.

Solution:
- Added filter script execution on overview load
- Ensures filter state persists during month navigation
